### PR TITLE
exit with non-zero code when timer cancelled

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,7 @@ fn main() -> anyhow::Result<()> {
             AppEvent::Input(event) => match event.code {
                 KeyCode::Char('q') | KeyCode::Esc => {
                     preexit(&mut terminal);
-                    std::process::exit(0);
+                    std::process::exit(1);
                 }
                 KeyCode::Char('p') => {
                     timer.toggle();

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -39,7 +39,7 @@ impl Timer {
         lines.into_iter().map(Spans::from).collect::<Vec<Spans>>()
     }
 
-    fn push_number(&self, num: u64, lines: &mut Vec<String>) {
+    fn push_number(&self, num: u64, lines: &mut [String]) {
         let s = format!("{:02}", num);
         let mut chars = s.chars().peekable();
         while let Some(ch) = chars.next() {
@@ -50,7 +50,7 @@ impl Timer {
         }
     }
 
-    fn push_digit(&self, ch: char, lines: &mut Vec<String>) {
+    fn push_digit(&self, ch: char, lines: &mut [String]) {
         for (i, &line) in digit(ch).iter().enumerate() {
             let mut s = String::default();
             for &v in line.iter() {
@@ -64,7 +64,7 @@ impl Timer {
         }
     }
 
-    fn push_space(&self, lines: &mut Vec<String>) {
+    fn push_space(&self, lines: &mut [String]) {
         for line in lines.iter_mut() {
             line.push(' ');
         }


### PR DESCRIPTION
This commit is the minimal possible implementation of #2.

This *might* break backwards compatibility if someone is depending on the current behaviour (exit with `0` even when cancelled). A flag to enable the new behaviour would prevent that at the expense of having a more complicated interface; I'm happy to put that together if it would be preferable.